### PR TITLE
Fix Linking Error Caused by Protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.30)
 
 project(gnss-sdr-monitor CXX)
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $ git clone https://github.com/acebrianjuan/gnss-sdr-monitor
 
 ~~~~~~
 $ cd gnss-sdr-monitor/build
-$ cmake ..
+$ cmake -Dprotobuf_MODULE_COMPATIBLE:BOOL=ON ..
 $ make
 ~~~~~~
 
@@ -165,4 +165,3 @@ $ sudo make install
 $ cd src/
 $ ./gnss-sdr-monitor
 ~~~~~~
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT Boost_FOUND)
      message(FATAL_ERROR "Fatal error: Boost required.")
 endif()
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf REQUIRED CONFIG)
 if(${Protobuf_VERSION} VERSION_LESS "3.0.0")
      message(FATAL_ERROR "Fatal error: Protocol Buffers > v3.0.0 required.")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT Boost_FOUND)
      message(FATAL_ERROR "Fatal error: Boost required.")
 endif()
 
-find_package(Protobuf REQUIRED CONFIG)
+find_package(Protobuf REQUIRED)
 if(${Protobuf_VERSION} VERSION_LESS "3.0.0")
      message(FATAL_ERROR "Fatal error: Protocol Buffers > v3.0.0 required.")
 endif()
@@ -71,6 +71,6 @@ set(RESOURCES
 
 add_executable(${TARGET} ${SOURCES} ${UI_SOURCES} ${RESOURCES})
 
-target_link_libraries(${TARGET} PUBLIC ${QT5_LIBRARIES} Boost::boost protobuf::libprotobuf)
+target_link_libraries(${TARGET} PUBLIC ${QT5_LIBRARIES} Boost::boost ${Protobuf_LIBRARIES})
 
 install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/protobuf/gnss_synchro.proto
+++ b/src/protobuf/gnss_synchro.proto
@@ -34,6 +34,7 @@ message GnssSynchro {
    double rx_time = 23;  // Receiving time after the start of the week, in s
    bool flag_valid_pseudorange = 24;  // Pseudorange computation status
    double interp_tow_ms = 25;  // Interpolated time of week, in ms
+   bool flag_PLL_180_deg_phase_locked = 26; // PLL lock at 180º
 }
 
 /* Observables represents a collection of GnssSynchro annotations */

--- a/src/protobuf/monitor_pvt.proto
+++ b/src/protobuf/monitor_pvt.proto
@@ -39,4 +39,16 @@ double gdop = 25;  // Geometric Dilution of Precision
 double pdop = 26;  // Position (3D) Dilution of Precision
 double hdop = 27;  // Horizontal Dilution of Precision
 double vdop = 28;  // Vertical Dilution of Precision
+
+double user_clk_drift_ppm = 29;  // User clock drift [ppm]
+string utc_time = 30;  // PVT UTC time (rfc 3339 datetime string)
+
+double vel_e = 31;  // Velocity East component in the local frame, in m/s
+double vel_n = 32;  // Velocity North component in the local frame, in m/s
+double vel_u = 33;  // Velocity Up component in the local frame, in m/s
+
+double cog = 34;  // Course Over Ground, in deg
+
+uint32 galhas_status = 35;  // Galileo HAS status: 1- HAS messages decoded and applied, 0 - HAS not available
+string geohash = 36;  // Encoded geographic location. See https://en.wikipedia.org/wiki/Geohash
 }


### PR DESCRIPTION
Whenever I attempt to run `make`, it fails because `ld` can't find "`_ZN4absl12lts_2023080212log_internal17MakeCheckOpStringIllEEPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_T0_PKc`":
```
[jacob@jacobarch build]$ make
[  0%] Built target gnss-sdr-monitor_autogen_timestamp_deps
[  4%] Built target gnss-sdr-monitor_autogen
[  8%] Linking CXX executable gnss-sdr-monitor
/usr/bin/ld: CMakeFiles/gnss-sdr-monitor.dir/channel_table_model.cpp.o: undefined reference to symbol '_ZN4absl12lts_2023080212log_internal17MakeCheckOpStringIllEEPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_T0_PKc'
/usr/bin/ld: /usr/lib/libabsl_log_internal_check_op.so.2308.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/gnss-sdr-monitor.dir/build.make:420: src/gnss-sdr-monitor] Error 1
make[1]: *** [CMakeFiles/Makefile2:101: src/CMakeFiles/gnss-sdr-monitor.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
[jacob@jacobarch build]$
```

This can be fixed by implementing the changes found here: <https://stackoverflow.com/a/77151107>

Basically, changing:
```
find_package(Protobuf REQUIRED)
```
in `CMakeLists.txt` to:
```
find_package(Protobuf REQUIRED CONFIG)
```
which causes CMake to say:
```
Unknown CMake command "protobuf_generate_cpp"
```
but it's OK because you can make it shut up by adding `-Dprotobuf_MODULE_COMPATIBLE:BOOL=ON` when you run `cmake` (I added the updated CMake command to the README).